### PR TITLE
feat: Remove Itemgroup for building ConsoleApp

### DIFF
--- a/ConsoleApp88/ConsoleApp88.csproj
+++ b/ConsoleApp88/ConsoleApp88.csproj
@@ -7,17 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Fody" Version="6.6.4">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-		<WeaverFiles Include="$(SolutionDir)MetaMerge.Fody\bin\$(Configuration)\netstandard2.0\MetaMerge.Fody.dll" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\ConsoleApp88.Contracts\ConsoleApp88.Contracts.csproj" />
 	  <ProjectReference Include="..\MetaMerge.Contracts\MetaMerge.Contracts.csproj" />
 	  <ProjectReference Include="..\MetaMerge.Fody\MetaMerge.Fody.csproj" />
 	</ItemGroup>
-
 </Project>

--- a/ConsoleApp88/Program.cs
+++ b/ConsoleApp88/Program.cs
@@ -1,6 +1,5 @@
 ﻿using ConsoleApp88.Contracts;
 using MetaMerge.Contracts;
-using System.ComponentModel.DataAnnotations;
 
 namespace ConsoleApp88
 {


### PR DESCRIPTION
If you leave the references to Fody inside the console App itself and the WeaverFiles it would not compile.
When removed, it's compiling. 